### PR TITLE
User::PasswordAuthentication の db schema, ActiveRecord, seed, factory を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 gem 'ridgepole'
 gem 'slim-rails'
 gem 'active_decorator'
+gem 'bcrypt'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
     awesome_print (1.8.0)
+    bcrypt (3.1.13)
     bindex (0.8.1)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
@@ -275,6 +276,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_decorator
+  bcrypt
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)

--- a/Schemafile
+++ b/Schemafile
@@ -1,1 +1,2 @@
 require "schemata/users.rb"
+require "schemata/user/password_authentications.rb"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,3 @@
 class User < ApplicationRecord
+  has_one :password_authentication
 end

--- a/app/models/user/password_authentication.rb
+++ b/app/models/user/password_authentication.rb
@@ -1,0 +1,5 @@
+class User::PasswordAuthentication < ApplicationRecord
+  has_secure_password
+
+  belongs_to :user
+end

--- a/db/seed/development.rb
+++ b/db/seed/development.rb
@@ -1,1 +1,2 @@
 require_relative "development/users"
+require_relative "development/user/password_authentications"

--- a/db/seed/development/user/password_authentications.rb
+++ b/db/seed/development/user/password_authentications.rb
@@ -1,0 +1,3 @@
+User.find_by!(email: "test@hugeman.com").tap do |user|
+  user.password_authentication || user.create_password_authentication!(password: "password")
+end

--- a/schemata/user/password_authentications.rb
+++ b/schemata/user/password_authentications.rb
@@ -1,0 +1,14 @@
+create_table :user_password_authentications do |t|
+  t.references :user,
+               null: false,
+               index: {
+                 unique: true,
+                 name: :idx_user_password_authentications_1,
+               }
+  t.string :password_digest,
+           null: false
+end
+
+add_foreign_key :user_password_authentications,
+                :users,
+                name: :fk_user_password_authentications_1

--- a/spec/factories/user_password_authentications.rb
+++ b/spec/factories/user_password_authentications.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user_password_authentication, class: User::PasswordAuthentication do
+    user
+    password { "password" }
+  end
+end


### PR DESCRIPTION
## Why
User::PasswordAuthentication に関するリソースが存在しないため

## How
- user_password_authentications テーブルの schema を作成
- User::PasswordAuthentication の ApplicationRecord モデルを作成
- User::PasswordAuthentication のseed データを用意
- User::PasswordAuthentication の factory を用意