### PR TITLE
add-foreign_key_to_schemata/events.rb

### DIFF
--- a/schemata/events.rb
+++ b/schemata/events.rb
@@ -30,3 +30,7 @@ create_table :events do |t|
              name: :idx_events_5,
            }
 end
+
+add_foreign_key :events,
+                :nightclubs,
+                name: :fk_events_1


### PR DESCRIPTION
 # WHY
schemata/events.rbに外部キー制約がなかったので

# HOW 
- schemata/events.rbにnightclubsに対する外部キー制約を設定