### PR TITLE
Feature/add event list

### DIFF
--- a/app/controllers/event_management/events_controller.rb
+++ b/app/controllers/event_management/events_controller.rb
@@ -1,5 +1,6 @@
 class EventManagement::EventsController < EventManagement::ApplicationController
   def index
+    @event_management_event = EventManagement::Event.all
   end
 
   def show

--- a/app/models/event_management/event.rb
+++ b/app/models/event_management/event.rb
@@ -1,6 +1,10 @@
 class EventManagement::Event < ApplicationModel
   attribute :event, default: -> { Event.new }
-  
+
+  def self.all
+    new(event: Event.all)
+  end
+
   def self.find(id)
     new(event: Event.find(id))
   end

--- a/app/views/event_management/events/index.html.slim
+++ b/app/views/event_management/events/index.html.slim
@@ -1,0 +1,21 @@
+div class="px-2 pt-6 pb-8 mx-4 flex flex-col my-4 "
+  h4 class="text-gray-100 mx-3 md:flex my-10"
+    | 登録済みのイベント
+  div class="max-w-sm.rounded.overflow-hidden.shadow-lg text-gray-100"
+    - @event_management_event.event.each do |event|
+      = link_to "https://www.google.com/", class: "px-2 pb-8 flex flex-col my-4"
+        div class="w-full  lg:w-11/12 xl:w-full px-1 bg-white py-5 lg:px-2 lg:py-2 tracking-wide"
+          div class="flex flex-row lg:justify-start justify-center"
+            div class="text-gray-700 font-medium text-sm text-center lg:text-left px-2"
+              i class="i far fa-clock"
+              = event.start_at.in_time_zone('Tokyo').strftime("%Y-%m-%d %H:%M:%S")
+            div class="text-gray-700 font-medium text-sm text-center lg:text-left px-2"
+              = event.end_at.in_time_zone('Tokyo').strftime("%Y-%m-%d %H:%M:%S")
+          div class="font-semibold text-gray-800 text-xl text-center lg:text-left px-2"
+            = event.name
+          div class="text-gray-600 font-medium text-sm pt-1 text-center lg:text-left px-2"
+            = event.nightclub.name
+          div class="text-gray-600 font-medium text-sm pt-1 text-center lg:text-left px-2"
+            - event.artists.each do |ar|
+              = ar.name
+


### PR DESCRIPTION
# WHY
イベント管理者向けのイベント一覧画面がないので

# WHAT
- 管理ユーザーが　http://localhost:3000/event_management/events　にGETリクエストした際にイベント一覧を表示するようにした。

# 該当の画面のスクショ
![image](https://user-images.githubusercontent.com/51050558/72279240-0c170780-3679-11ea-994f-df3aa6a67ede.png)
