### PR TITLE
管理者向けのイベント一覧画面を追加

### DIFF
--- a/app/controllers/event_management/events_controller.rb
+++ b/app/controllers/event_management/events_controller.rb
@@ -1,9 +1,9 @@
 class EventManagement::EventsController < EventManagement::ApplicationController
   def index
+    @event_management_events = EventManagement::Event.filter_user_by(@current_user.id)
   end
 
   def show
     @event_management_event = EventManagement::Event.find(params[:id])
   end
-
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -6,4 +6,6 @@ class Event < ApplicationRecord
   has_many :organizers
   has_many :artist_identifyings
   has_many :artists, through: :artist_identifyings
+
+  delegate :name, prefix: true, to: :nightclub
 end

--- a/app/models/event_management/event.rb
+++ b/app/models/event_management/event.rb
@@ -1,6 +1,11 @@
 class EventManagement::Event < ApplicationModel
   attribute :event, default: -> { Event.new }
-  
+
+  def self.filter_user_by(args)
+    user = User.find(args)
+    user.events
+  end
+
   def self.find(id)
     new(event: Event.find(id))
   end

--- a/app/views/event_management/events/index.html.slim
+++ b/app/views/event_management/events/index.html.slim
@@ -1,0 +1,21 @@
+div class="px-2 pt-6 pb-8 mx-4 flex flex-col my-4 "
+  h4 class="text-gray-100 mx-3 md:flex my-10"
+    | 登録済みのイベント
+  div class="max-w-sm.rounded.overflow-hidden.shadow-lg text-gray-100"
+    - @event_management_events.each do |event|
+      = link_to "https://www.google.com/", class: "px-2 pb-8 flex flex-col my-4"
+        div class="w-full  lg:w-11/12 xl:w-full px-1 bg-white py-5 lg:px-2 lg:py-2 tracking-wide"
+          div class="flex flex-row lg:justify-start justify-center"
+            div class="text-gray-700 font-medium text-sm text-center lg:text-left px-2"
+              i class="i far fa-clock"
+              = event.start_at.in_time_zone('Tokyo').strftime("%Y-%m-%d %H:%M:%S")
+            div class="text-gray-700 font-medium text-sm text-center lg:text-left px-2"
+              = event.end_at.in_time_zone('Tokyo').strftime("%Y-%m-%d %H:%M:%S")
+          div class="font-semibold text-gray-800 text-xl text-center lg:text-left px-2"
+            = event.name
+          div class="text-gray-600 font-medium text-sm pt-1 text-center lg:text-left px-2"
+            = event.nightclub.name
+          div class="text-gray-600 font-medium text-sm pt-1 text-center lg:text-left px-2"
+            - event.artists.each do |ar|
+              = ar.name
+

--- a/app/views/event_management/events/index.html.slim
+++ b/app/views/event_management/events/index.html.slim
@@ -14,7 +14,7 @@ div class="px-2 pt-6 pb-8 mx-4 flex flex-col my-4 "
           div class="font-semibold text-gray-800 text-xl text-center lg:text-left px-2"
             = event.name
           div class="text-gray-600 font-medium text-sm pt-1 text-center lg:text-left px-2"
-            = event.nightclub.name
+            = event.nightclub_name
           div class="text-gray-600 font-medium text-sm pt-1 text-center lg:text-left px-2"
             - event.artists.each do |ar|
               = ar.name

--- a/spec/models/event_management/event_spec.rb
+++ b/spec/models/event_management/event_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe EventManagement::Event, type: :model do
+  describe ".filter_user_by" do
+    subject { EventManagement::Event.filter_user_by(args) }
+    let!(:args) { user.id }
+    let!(:user) { create(:user) }
+
+    it "returns events with login user" do
+      user = User.find(args)
+      expect(User.count).to eq(1)
+      subject
+      expect(User.count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
# WHY 
- 管理者向けのイベント一覧画面を追加がないので

# WHAT
- イベント一覧画面を追加
- app/controllers/event_management/events_controller.rb にログインユーザのidに紐づいたイベントを取得できるメソッドを追加
- app/models/event_management/event.rb  にwhereメソッドを追加