### PR TITLE
ツイート取得 job 第一弾: ツイートを取得して保存するためのモデルを追加

### DIFF
--- a/app/models/task/tweet_fetcher.rb
+++ b/app/models/task/tweet_fetcher.rb
@@ -1,0 +1,31 @@
+class Task::TweetFetcher < ApplicationModel
+  attribute :event
+
+  def execute!
+    payload =
+      twitter_api_search_client.call(
+        search_word: event.tag,
+        from_date: from_date,
+        to_date: to_date,
+      )
+
+    payload["results"].each do |result|
+      event.tweets.find_or_create_by!(url: result["id"].to_s)
+    end
+  end
+
+  private
+
+  def twitter_api_search_client
+    @twitter_api_search_client = TwitterApiSearchClient.new
+  end
+
+  def from_date
+    event.start_at.strftime("%Y%m%d%H%M")
+  end
+
+  def to_date
+    event.end_at.strftime("%Y%m%d%H%M")
+  end
+end
+

--- a/app/models/twitter_api_search_client.rb
+++ b/app/models/twitter_api_search_client.rb
@@ -1,4 +1,4 @@
-class TwittetApiSearchClient
+class TwitterApiSearchClient
   require "net/http"
   require "uri"
   require "json"
@@ -24,6 +24,7 @@ class TwittetApiSearchClient
     response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true ) do |http|
       http.request(request)
     end
-    response.body
+
+    JSON.parse(response.body)
   end
 end

--- a/spec/models/task/tweet_fetcher_spec.rb
+++ b/spec/models/task/tweet_fetcher_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+describe Task::TweetFetcher do
+  describe "#execute!" do
+    subject { task_tweet_fetcher.execute! }
+
+    let!(:event) { create(:event) }
+    let!(:task_tweet_fetcher) { Task::TweetFetcher.new(event: event) }
+    let!(:tweet_id_1) { 1234123412341234 }
+    let!(:tweet_id_2) { 5678567856785678 }
+    let!(:mock_payload) do
+      {"results"=>
+        [
+          { "id"=>tweet_id_1 },
+          { "id"=>tweet_id_1 },
+          { "id"=>tweet_id_2 },
+          { "id"=>tweet_id_2 },
+        ]
+      }
+    end
+    let(:twitte_api_search_client_double) { double(:twitte_api_search_client_double) }
+
+    before do
+      allow(TwitterApiSearchClient).to receive(:new) { twitte_api_search_client_double }
+      allow(twitte_api_search_client_double).to receive(:call)
+                               .with(
+                                 search_word: event.tag,
+                                 from_date: event.start_at.strftime("%Y%m%d%H%M"),
+                                 to_date: event.end_at.strftime("%Y%m%d%H%M"),
+                                )
+                               .and_return(mock_payload)
+    end
+
+    it "create tweet records" do
+      expect(Event::Tweet.count).to eq(0)
+
+      subject
+
+      expect(Event::Tweet.count).to eq(2)
+      expect(event.tweets.first.url).to eq(tweet_id_1.to_s)
+      expect(event.tweets.second.url).to eq(tweet_id_2.to_s)
+    end
+  end
+end


### PR DESCRIPTION
## 目的
ツイート取得 job 第一弾として、まずツイートを取得して保存するためのモデルを追加します
この後、
- ツイートを取得して保存する job の作成
- ツイートを取得して保存する job をキューに詰める job の作成
をします

## やったこと
コミットを参照