### PR TITLE
ツイート取得 job 第2弾: イベントに対してツイートを取得して保存する job を追加

### DIFF
--- a/app/jobs/tweet_fetch_job.rb
+++ b/app/jobs/tweet_fetch_job.rb
@@ -1,0 +1,6 @@
+class TweetFetchJob < ApplicationJob
+  def perform(event)
+    job_runner = JobRunner.new(event)
+    job_runner.execute!
+  end
+end

--- a/app/jobs/tweet_fetch_job/job_runner.rb
+++ b/app/jobs/tweet_fetch_job/job_runner.rb
@@ -1,0 +1,37 @@
+class TweetFetchJob::JobRunner
+  attr_reader :event
+
+  def initialize(event)
+    @event = event
+  end
+
+  def execute!
+    with_log do
+      task_tweet_fetcher.execute!
+    end
+  end
+
+  private
+
+  def task_tweet_fetcher
+    @task_tweet_fetcher ||=
+      ::Task::TweetFetcher.new(event: event)
+  end
+
+  def logger
+    Rails.logger
+  end
+
+  def with_log
+    begin
+      logger.info("Fetch tweets for Event[#{event.id}]")
+      yield
+      logger.info("Fetched tweets for Event[#{event.id}]")
+    rescue => e
+      logger.fatal(e.full_message)
+      logger.fatal(e.backtrace.join("\n"))
+      logger.info("Failed to Fetche tweets for Event[#{event.id}]")
+      raise
+    end
+  end
+end

--- a/spec/jobs/tweet_fetch_job/job_runner_spec.rb
+++ b/spec/jobs/tweet_fetch_job/job_runner_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+describe TweetFetchJob::JobRunner do
+  describe ".execute!" do
+    subject { tweet_fetch_job_job_runner.execute! }
+
+    let!(:tweet_fetch_job_job_runner) { TweetFetchJob::JobRunner.new(event) }
+    let!(:event) { create(:event) }
+
+    let!(:task_tweet_fetcher_double) { double(:task_tweet_fetcher) }
+
+    it "will call ::Task::TweetFetcher#execute!" do
+      expect(::Task::TweetFetcher).to(
+        receive(:new).with(event: event)
+      ).and_return(task_tweet_fetcher_double)
+
+      expect(task_tweet_fetcher_double).to(
+        receive(:execute!)
+      )
+
+      subject
+    end
+  end
+end

--- a/spec/jobs/tweet_fetch_job_spec.rb
+++ b/spec/jobs/tweet_fetch_job_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe TweetFetchJob do
+  describe "#perform_later" do
+    subject { TweetFetchJob.perform_later(event) }
+
+    let!(:event) { create(:event) }
+
+    it "enqueue job" do
+      expect { subject }.to have_enqueued_job.with(event)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,6 +34,8 @@ require 'rspec/rails'
 #   exit 1
 # end
 RSpec.configure do |config|
+  ActiveJob::Base.queue_adapter = :test
+
   Dir[Rails.root.join('spec', 'shared_context', '**', '*.rb')].each { |f| require f }
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
@@ -71,4 +73,9 @@ RSpec.configure do |config|
   end
 
   config.include ActiveSupport::Testing::TimeHelpers
+
+  config.after :each do
+    ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+    ActiveJob::Base.queue_adapter.performed_jobs.clear
+  end
 end


### PR DESCRIPTION
## 目的
ツイート取得 job 第2弾として、イベントに対してツイートを取得して保存する job を追加
この後、
- ツイートを取得して保存する job をキューに詰める job の作成
をします

## やったこと
コミットを参照