### PR TITLE
ツイート取得 job 第3弾: イベントに対してツイートを取得して保存する job をキューイングする job を追加

### DIFF
--- a/app/jobs/enqueue_tweet_fetch_job.rb
+++ b/app/jobs/enqueue_tweet_fetch_job.rb
@@ -1,0 +1,6 @@
+class EnqueueTweetFetchJob < ApplicationJob
+  def perform
+    job_runner = JobRunner.new
+    job_runner.execute!
+  end
+end

--- a/app/jobs/enqueue_tweet_fetch_job/job_runner.rb
+++ b/app/jobs/enqueue_tweet_fetch_job/job_runner.rb
@@ -1,0 +1,28 @@
+class EnqueueTweetFetchJob::JobRunner
+  def execute!
+    with_log do
+      Event.featured.each do |event|
+        TweetFetchJob.perform_later(event)
+      end
+    end
+  end
+
+  private
+
+  def logger
+    Rails.logger
+  end
+
+  def with_log
+    begin
+      logger.info("Enqueue Tweet Fetch Job")
+      yield
+      logger.info("Enqueued Tweet Fetch Job")
+    rescue => e
+      logger.fatal(e.full_message)
+      logger.fatal(e.backtrace.join("\n"))
+      logger.info("Faild to enqueue Tweet Fetch Job")
+      raise
+    end
+  end
+end

--- a/spec/jobs/enqueue_tweet_fetch_job/job_runner_spec.rb
+++ b/spec/jobs/enqueue_tweet_fetch_job/job_runner_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+describe EnqueueTweetFetchJob::JobRunner do
+  describe ".execute!" do
+    subject { enqueue_tweet_fetch_job_job_runner.execute! }
+
+    let!(:enqueue_tweet_fetch_job_job_runner) { EnqueueTweetFetchJob::JobRunner.new }
+    let!(:frozen_now) { Time.zone.parse("2019/11/01 20:00:00") }
+    let!(:task_tweet_fetcher_double) { double(:task_tweet_fetcher) }
+
+    context "with featured event" do
+      let!(:event) { create(:event, start_at: Time.zone.parse("2019/11/01 19:00:00"), end_at: Time.zone.parse("2019/11/01 23:00:00"))}
+
+      it "enqueues TweetFetchJob" do
+        travel_to frozen_now do
+          subject
+
+          expect(TweetFetchJob).to(
+            have_been_enqueued.with(event)
+          )
+        end
+      end
+    end
+
+    context "without featured event" do
+      let!(:event) { create(:event, start_at: Time.zone.parse("2019/12/01 19:00:00"), end_at: Time.zone.parse("2019/12/01 23:00:00"))}
+
+      it "enqueues TweetFetchJob" do
+        travel_to frozen_now do
+          subject
+
+          expect(TweetFetchJob).not_to(
+            have_been_enqueued.with(event)
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/enqueue_tweet_fetch_job_spec.rb
+++ b/spec/jobs/enqueue_tweet_fetch_job_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+describe EnqueueTweetFetchJob do
+  describe "#perform_later" do
+    subject { EnqueueTweetFetchJob.perform_later }
+
+    it "enqueue job" do
+      expect { subject }.to have_enqueued_job
+    end
+  end
+end


### PR DESCRIPTION
## 目的
ツイート取得 job 第3弾として、イベントに対してツイートを取得して保存する job キューイングできるようにする

## やったこと
コミットを参照